### PR TITLE
Fix error in _find_threaded, make sure tests run in thread mode

### DIFF
--- a/src/vantage_point_tree.jl
+++ b/src/vantage_point_tree.jl
@@ -208,7 +208,7 @@ function _find_threaded(vantage_point, query, radius, results, metric, skip)
     goleft = distance + radius >= vantage_point.radius && !isnothing(vantage_point.right_child) && distance - radius <= vantage_point.max_dist
     if distance - radius <= vantage_point.radius && !isnothing(vantage_point.left_child) && distance + radius >= vantage_point.min_dist
         if goleft && vantage_point.n_data > SMALL_DATA
-            r = Threads.@spawn _find_threaded(vantage_point.left_child, query, radius, results, metric)
+            r = Threads.@spawn _find_threaded(vantage_point.left_child, query, radius, results, metric, skip)
         else
             _find_threaded(vantage_point.left_child, query, radius, results, metric, skip)
         end


### PR DESCRIPTION
Forgot to add `skip` argument to recursive call in `_find_threaded` in previous PR. This wasn't caught by the tests because they either weren't running the threaded search or the data set was too small to trigger a new thread to spawn (which was where the error was). Updated tests to use large data sets (at least 10,000, 10x larger than the 1000 required to spawn a new thread in a recursive call) and to explicitly build the tree with both `threaded=true` and `threaded=false`.