### PR TITLE
Allow later minor version #s of DataStructures 0.15

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 julia = "1.3"
-DataStructures = "~0.15"
+DataStructures = ">=0.15, <1"
 
 [extras]
 StringDistances = "88034a9c-02f8-509d-84a9-84ec65e18404"


### PR DESCRIPTION
I think this is what it was intended to be, but `~` handles version #s with leading zeros as a special case. This allows the most recent version of DataStructures, `0.17`.